### PR TITLE
Fix Python 2.7 build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='psycopg-nestedtransactions',
       description='Database transaction manager for psycopg2 database connections with seamless support for nested transactions.',
       url='https://github.com/asqui/psycopg-nestedtransactions',
       packages=['nestedtransactions'],
-      install_requires=['psycopg2'],
+      install_requires=['psycopg2', 'pg8000<=1.12.4;python_version<"3"'],
       extras_require=dict(
           test=['pytest', 'testing.postgresql']
       )


### PR DESCRIPTION
testing.postgresql uses pg8000 and the latest version of pg8000 drops
support for Python 2. Pin the version of pg8000 used on Python 2 until
this PR is incorporated into the testing.postgresql project:
https://github.com/tk0miya/testing.postgresql/pull/29

(After that, this commit can be reverted)