### PR TITLE
Ensure patching commit/rollback does not introduce instance-level attrs

### DIFF
--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -365,6 +365,22 @@ def test_manual_transaction_management_with_connection_subclass_commit_rollback_
     assert_rows(other_cxn, set())
 
 
+def test_commit_and_rollback_unchanged_after_transaction_block(python_cxn):
+    # See: https://github.com/asqui/psycopg-nestedtransactions/issues/11
+    def check(cxn):
+        original_commit, original_rollback = cxn.commit, cxn.rollback
+        original_dict_keys = set(cxn.__dict__.keys())
+        with Transaction(cxn):
+            pass
+        assert (original_commit, original_rollback) == (cxn.commit, cxn.rollback)
+        assert original_dict_keys == set(cxn.__dict__.keys()), 'Instance dict has changed'
+
+    check(python_cxn)
+    python_cxn.commit = python_cxn.commit
+    python_cxn.rollback = python_cxn.rollback
+    check(python_cxn)
+
+
 def test_transactions_on_multiple_connections_are_independent(cxn, other_cxn):
     with Transaction(cxn) as outer_txn:
         insert_row(cxn, 'outer')


### PR DESCRIPTION
In the usual scenario, commit() and rollback() are methods defined on
the connection type, not the instance. Naive patching and restore which
simplifies down to `cxn.commit = cxn.commit` is not a no-op, because it
will take a method defined on the connection type and turn it in to a
bound instance method and add it to the instance dict of the connection.

The correct approach is to take note if the method is defined locally
before patching, and if not, undo the patch by deleting from the
instance dict, rather than assigning to it.

Fixes #11